### PR TITLE
Specifically post error and success messages via subprocesses rather than writing to StdOut

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -5,25 +5,17 @@
 # function's deployment package, alongside this bootstrap executable.
 source $(dirname "$0")/"$(echo "$_HANDLER" | cut -d. -f1).sh"
 
-RUNTIME_API_ADDRESS="http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation"
+export RUNTIME_API_ADDRESS="http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation"
 
 while true
 do
     # Request the next event from the Lambda runtime
     HEADERS="$(mktemp)"
     EVENT_DATA=$(curl -sS -LD "$HEADERS" -X GET "$RUNTIME_API_ADDRESS/next")
-    INVOCATION_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
+    export INVOCATION_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
 
     # Execute the handler function from the script
     echo "$EVENT_DATA"
-    RESPONSE=$($(echo "$_HANDLER" | cut -d. -f2) "$EVENT_DATA")
-
-    if [ "$?" = "0" ]; then
-      # Send the response to Lambda runtime with success
-      curl -sS -X POST "$RUNTIME_API_ADDRESS/$INVOCATION_ID/response" -d "$RESPONSE"
-    else
-      # Send the response to Lambda runtime with error
-      curl -sS -X POST "$RUNTIME_API_ADDRESS/$INVOCATION_ID/error" -d "$RESPONSE"
-    fi
+    $(echo "$_HANDLER" | cut -d. -f2) "$EVENT_DATA"
 
 done

--- a/build.sbt
+++ b/build.sbt
@@ -61,3 +61,5 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic",
   "io.circe" %% "circe-parser")
   .map(_ % circeVersion)
+
+libraryDependencies += "com.lihaoyi" %% "pprint" % "0.5.6"

--- a/src/main/scala/LambdaFunction.scala
+++ b/src/main/scala/LambdaFunction.scala
@@ -33,9 +33,15 @@ abstract class LambdaFunction[Input: Decoder, Err: Encoder, Output: Encoder] {
         case Left(err) =>
           (RUNTIME_API_ADDRESS, INVOCATION_ID) match {
             case (Some(r), Some(i)) =>
-              s"""curl -sS -X POST $r/$i/error \\
-              | -d '${ParseError(arg, err.getMessage).asJson.toString}'
-              |""".stripMargin.!
+              Seq(
+                s"curl",
+                "-sS",
+                "-X",
+                "POST",
+                s"$r/$i/error",
+                "-d",
+                ParseError(arg, err.getMessage).asJson.toString
+                  .replace("\n", " ")).!
             case _ =>
               pprint.log(ParseError(arg, err.getMessage).asJson.toString)
           }
@@ -47,10 +53,10 @@ abstract class LambdaFunction[Input: Decoder, Err: Encoder, Output: Encoder] {
                 s"curl",
                 "-sS",
                 "-X",
-                "POST" ,
+                "POST",
                 s"$r/$i/error",
                 "-d",
-                "{\"key1\" : \"value1\",\"key2\" : \"value2\",\"key3\" : \"value3\"}").!
+                value.asJson.toString.replace("\n", " ")).!
             case _ => pprint.log(value.asJson.toString)
           }
           System.exit(1)
@@ -61,15 +67,14 @@ abstract class LambdaFunction[Input: Decoder, Err: Encoder, Output: Encoder] {
                 s"curl",
                 "-sS",
                 "-X",
-                "POST" ,
+                "POST",
                 s"$r/$i/response",
                 "-d",
-                "{\"key1\" : \"value1\",\"key2\" : \"value2\",\"key3\" : \"value3\"}").!
+                value.asJson.toString.replace("\n", " ")).!
             case _ => pprint.log(value.asJson.toString)
           }
           System.exit(0)
       }
       .unsafeRunSync()
-    // ${value.asJson.toString.replace("\n", " ")}
   }
 }


### PR DESCRIPTION
## What do? 


Beforehand, we would signal success via a unix signal (1 or 0 as s return code) and expect all results to be printed via stdout. 

This was inconvenient because we were then unable to print anything  without it being interpreted as a response message. 

We now make a curl call to the lambda socket, explicitly passing the error or success playloads. 


Also, freebie, we can now run this thing from `sbt run`